### PR TITLE
Update README.md to remove Eventbox link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ecs-devops-sandbox-cdk
 
-This CDK app accompanies the workshop located at [here](https://www.eventbox.dev/published/lesson/automating-cicd-on-aws-with-github-actions/index.html).
+This CDK app accompanies the workshop located at [here.](https://www.jennapederson.com/blog/automate-your-container-deployments-with-ci-cd-and-github-actions/)
 
 ## Setup
 


### PR DESCRIPTION
Eventbox is deprecated and we need to remove all links to it.